### PR TITLE
Update video_llama_stage1_pretrain.yaml to prevent AttributeError: 

### DIFF
--- a/train_configs/video_llama_stage1_pretrain.yaml
+++ b/train_configs/video_llama_stage1_pretrain.yaml
@@ -34,7 +34,7 @@ datasets:
     text_processor:
       train:
         name: "blip_caption"
-  sample_ratio: 100
+    sample_ratio: 100
 
   cc_sbu_align:
     data_type: images


### PR DESCRIPTION
Got this error:
 File "video_llama/common/config.py", line 102, in build_dataset_config
    dataset_config_type = **datasets[dataset_name].get("type", "default")**
AttributeError: 'int' object has no attribute 'get'

Due to indentation!